### PR TITLE
Fix missing screenshots

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,12 +167,12 @@ module.exports = (config) => {
 
       debug(`Attaching screenshot & error to failed step`);
   
-      const screenshot = await attachScreenshot();      
+      const screenshot = await attachScreenshot();
 
       resp = await rpClient.sendLog(step.tempId, {
         level: 'ERROR',
         message: `${err.stack}`,
-        time: step.startTime,
+        time: step.startTime || rpClient.helpers.now(),
       }, screenshot).promise; 
 
     }


### PR DESCRIPTION
Fix for missing uploaded screenshots. We faced problem with missing screenshot for all failes caused from Helper.
Problem is caused by missing **step.startTime** in **_beforeStep** created step - **rpClient.sendLog()** method needs log record time. In case step.startTime is missing use **now()** instead of missing log/screenshot. 